### PR TITLE
Fix/set experiment name

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-name: Manage Kubeflow Pipelines on GCP. 
+name: Manage Kubeflow Pipelines on GCP.
 description: Build, deploy and run a Kubeflow Pipeline on Google Cloud Platform.
 author: Anirudh G J
 inputs:
@@ -9,46 +9,45 @@ inputs:
     description: Flag for running recurring pipelines
     required: true
   KUBEFLOW_URL:
-    description: The endpoint where your Kubeflow UI is running. 
+    description: The endpoint where your Kubeflow UI is running.
     required: true
   CLIENT_ID:
     description: The IAP client id, which was specified when the kubeflow deployment where setup using IAP.
-    require: False
+    required: False
   PIPELINE_CODE_PATH:
     description: The full path name including the filename of the python file that describes the pipeline you want to run on Kubeflow.  This should be relative to the root of the GitHub repository where the Action is triggered.
-    require: true
+    required: true
   PIPELINE_PARAMETERS_PATH:
     description: Full path name including the filename of the parameters yaml file that contains the parameters for the kublefow pipeline
-    require: true
+    required: true
   PIPELINE_FUNCTION_NAME:
     description: The name of the pipeline, this name will be the name of the pipeline in the Kubeflow UI.
-    require: true
+    required: true
   ENCODED_GOOGLE_APPLICATION_CREDENTIALS:
     description: The base64 encoded google credentials
     required: true
   GOOGLE_APPLICATION_CREDENTIALS:
     description: The path to the decoded google credentials
     required: true
-  EXPERIMENT_NAME: 
+  EXPERIMENT_NAME:
     description: The name of the experiment name within which the kubeflow experiment should run
     required: false
-  PIPELINE_NAMESPACE: 
+  PIPELINE_NAMESPACE:
     description: The namespace in which the pipeline should run
     required: false
-  RUN_PIPELINE: 
+  RUN_PIPELINE:
     description: Should github action also trigger the pipeline
     required: false
-  VERSION_GITHUB_SHA: 
-    description: Should github action also trigger the pipeline
+  VERSION_GITHUB_SHA:
+    description: Flag for versioning with github sha
     required: false
 
-    
 outputs:
   WORKFLOW_URL:
     description: URL that is a link to pipeline in Kubeflow
 branding:
-  color: 'purple'
-  icon: 'upload-cloud'
+  color: "purple"
+  icon: "upload-cloud"
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"

--- a/main.py
+++ b/main.py
@@ -138,16 +138,12 @@ def upload_pipeline(pipeline_name_zip: str, pipeline_name: str, github_sha: str,
         pipeline_name_zip {str} -- The name of the compiled pipeline.ArithmeticError
         pipeline_name {str} -- The name of the pipeline function. This will be the name in the kubeflow UI. 
     """
-    # TODO: Remove after version up to v1.1
-    client.get_pipeline_id = get_pipeline_id
     pipeline_id = client.get_pipeline_id(pipeline_name)
     if pipeline_id is None:
         pipeline_id = client.upload_pipeline(
             pipeline_package_path=pipeline_name_zip,
             pipeline_name=pipeline_name).to_dict()["id"]
 
-    # TODO: Remove after version up to v1.1
-    client.upload_pipeline_version = upload_pipeline_version
     client.upload_pipeline_version(
         pipeline_package_path=pipeline_name_zip,
         pipeline_version_name=github_sha,
@@ -243,6 +239,10 @@ def main():
     if os.environ["INPUT_VERSION_GITHUB_SHA"] == "true":
         logging.info(f"Versioned pipeline components with : {github_sha}")
         pipeline_function = pipeline_function(github_sha=github_sha)
+
+    # TODO: Remove after version up to v1.1
+    kfp.Client.get_pipeline_id = get_pipeline_id
+    kfp.Client.upload_pipeline_version = upload_pipeline_version
 
     client = kfp.Client(host=os.environ['INPUT_KUBEFLOW_URL'])
     pipeline_name_zip = pipeline_compile(pipeline_function=pipeline_function)

--- a/main.py
+++ b/main.py
@@ -186,7 +186,7 @@ def run_pipeline_func(client: kfp.Client,
         ).to_dict()["id"]
     except ValueError:
         experiment_id = client.create_experiment(
-            experiment_name=experiment_name
+            name=experiment_name
         ).to_dict()["id"]
 
     namespace = os.getenv("INPUT_PIPELINE_NAMESPACE") if not str.isspace(

--- a/main.py
+++ b/main.py
@@ -6,9 +6,8 @@ import click
 import importlib.util
 import logging
 import sys
-import json 
+import json
 from datetime import datetime
-
 
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
@@ -29,8 +28,8 @@ def load_function(pipeline_function_name: str, full_path_to_pipeline: str) -> ob
         f"Loading the pipeline function from: {full_path_to_pipeline}")
     logging.info(
         f"The name of the pipeline function is: {pipeline_function_name}")
-    spec = importlib.util.spec_from_file_location(
-        pipeline_function_name, full_path_to_pipeline)
+    spec = importlib.util.spec_from_file_location(pipeline_function_name,
+                                                  full_path_to_pipeline)
     foo = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(foo)
     pipeline_func = getattr(foo, pipeline_function_name)
@@ -54,7 +53,7 @@ def pipeline_compile(pipeline_function: object) -> str:
 
 
 def upload_pipeline(pipeline_name_zip: str, pipeline_name: str, kubeflow_url: str):
-    """Function to upload pipeline to kubeflow. 
+    """ Function to upload pipeline to kubeflow.
 
     Arguments:
         pipeline_name_zip {str} -- The name of the compiled pipeline.ArithmeticError
@@ -65,13 +64,13 @@ def upload_pipeline(pipeline_name_zip: str, pipeline_name: str, kubeflow_url: st
     client.upload_pipeline(
         pipeline_package_path=pipeline_name_zip,
         pipeline_name=pipeline_name)
-    
+
     logging.info("the pipeline is uploaded")
     return client
 
 
 def find_pipeline_id(pipeline_name: str, client: kfp.Client, page_size: str = 100, page_token: str = "") -> str:
-    """Function to find the pipeline id of a pipeline. 
+    """ Function to find the pipeline id of a pipeline.
 
     Arguments:
         pipeline_name {str} -- The name of the pipeline of interest
@@ -91,8 +90,10 @@ def find_pipeline_id(pipeline_name: str, client: kfp.Client, page_size: str = 10
             if pipeline.name == pipeline_name:
                 logging.info(f"The pipeline id is: {pipeline.id}")
                 return pipeline.id
+
         # Start need to know where to do next itteration from
         page_token = pipelines.next_page_token
+
         # If no next tooken break
         if not page_token:
             logging.info(
@@ -111,18 +112,20 @@ def find_experiment_id(experiment_name: str, client: kfp.Client, page_size: int 
         str -- The experiment id
     """
     while True:
-        experiments = client.list_experiments(
-            page_size=page_size, page_token=page_token)
+        experiments = client.list_experiments(page_size=page_size,
+                                              page_token=page_token)
         for experiments in experiments.experiments:
             if experiments.name == experiment_name:
                 logging.info("Succesfully collected the experiment id")
                 return experiments.id
+
         # Start need to know where to do next itteration from
         page_token = experiments.next_page_token
+
         # If no next tooken break
         if not page_token:
             logging.info(
-                f"Could not find the pipeline id, is the experiment name: {experiments_name} correct? ")
+                f"Could not find the pipeline id, is the experiment name: {experiment_name} correct? ")
             break
 
 
@@ -136,80 +139,85 @@ def read_pipeline_params(pipeline_paramters_path: str) -> dict:
         except yaml.YAMLError as exc:
             logging.info("The yaml parameters could not be loaded correctly.")
             raise ValueError(
-                "The yaml parameters could not be loaded correctly.")
+                f"The yaml parameters could not be loaded correctly with {exc}.")
         logging.info(f"The paramters are: {pipeline_params}")
     return pipeline_params
 
 
-def run_pipeline_func(client: kfp.Client, pipeline_name: str, pipeline_id: str, pipeline_paramters_path: dict, recurring_flag :bool = False, cron_exp : str = ''):
+def run_pipeline_func(client: kfp.Client,
+                      pipeline_name: str,
+                      pipeline_id: str,
+                      pipeline_paramters_path: dict,
+                      recurring_flag: bool = False,
+                      cron_exp: str = ''):
 
-    
-    experiment_id = find_experiment_id(
-        experiment_name='Default', client=client)
+    experiment_id = find_experiment_id(experiment_name='Default',
+                                       client=client)
     if not experiment_id:
         raise ValueError("Failed to find experiment with the name: {}".format(
             os.environ["INPUT_EXPERIMENT_NAME"]))
     logging.info(f"The expriment id is: {experiment_id}")
+
     namespace = None
-    if (os.getenv("INPUT_PIPELINE_NAMESPACE") != None) and (str.isspace(os.getenv("INPUT_PIPELINE_NAMESPACE")) == False) and os.getenv("INPUT_PIPELINE_NAMESPACE"):
+    if (os.getenv("INPUT_PIPELINE_NAMESPACE") is not None) and (not str.isspace(os.getenv("INPUT_PIPELINE_NAMESPACE"))) and os.getenv("INPUT_PIPELINE_NAMESPACE"):
         namespace = os.environ["INPUT_PIPELINE_NAMESPACE"]
         logging.info(f"The namespace that will be used is: {namespace}")
+
     job_name = pipeline_name + datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
     logging.info(f"The job name is: {job_name}")
 
     pipeline_params = read_pipeline_params(
         pipeline_paramters_path=pipeline_paramters_path)
-    pipeline_params = pipeline_params if pipeline_params != None else {}
-    
-    logging.info(
-        f"experiment_id: {experiment_id}, job_name:{job_name}, pipeline_params:{pipeline_params}, pipeline_id:{pipeline_id}, namespace:{namespace}")
+    pipeline_params = pipeline_params if pipeline_params is not None else {}
+
+    logging.info(f"experiment_id: {experiment_id}, \
+                 job_name: {job_name}, \
+                 pipeline_params: {pipeline_params}, \
+                 pipeline_id: {pipeline_id}, \
+                 namespace: {namespace}")
     logging.info(cron_exp)
-    
-    if recurring_flag == "true" :
-        client.create_recurring_run(
-            experiment_id=experiment_id,
-            job_name=job_name,
-            params=pipeline_params,
-            pipeline_id=pipeline_id,
-            cron_expression=cron_exp)
+
+    if recurring_flag == "true":
+        client.create_recurring_run(experiment_id=experiment_id,
+                                    job_name=job_name,
+                                    params=pipeline_params,
+                                    pipeline_id=pipeline_id,
+                                    cron_expression=cron_exp)
         logging.info(
             "Successfully started the recurring pipeline, head over to kubeflow to check it out")
-        
-    client.run_pipeline(
-        experiment_id=experiment_id,
-        job_name=job_name,
-        params=pipeline_params,
-        pipeline_id=pipeline_id)
+
+    client.run_pipeline(experiment_id=experiment_id,
+                        job_name=job_name,
+                        params=pipeline_params,
+                        pipeline_id=pipeline_id)
     logging.info(
         "Successfully started the pipeline, head over to kubeflow to check it out")
 
+
 def main():
 
-    logging.info("Started the process to compile and upload the pipeline to kubeflow.")
-    logging.info("Authenticating") 
-    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = os.environ["INPUT_GOOGLE_APPLICATION_CREDENTIALS"]
+    logging.info(
+        "Started the process to compile and upload the pipeline to kubeflow.")
+    logging.info("Authenticating")
 
-    print (os.environ["GOOGLE_APPLICATION_CREDENTIALS"])
-
-    with open(os.environ["GOOGLE_APPLICATION_CREDENTIALS"]) as f:
+    ga_credentials = os.environ["INPUT_GOOGLE_APPLICATION_CREDENTIALS"]
+    with open(ga_credentials) as f:
         sa_details = json.load(f)
-
     os.system("gcloud auth activate-service-account {} --key-file={} --project={}".format(sa_details['client_email'],
-                                                                                          os.environ["GOOGLE_APPLICATION_CREDENTIALS"],
+                                                                                          ga_credentials,
                                                                                           sa_details['project_id']))
 
-    pipeline_function = load_function(pipeline_function_name=os.environ['INPUT_PIPELINE_FUNCTION_NAME'],
+    pipeline_function_name = os.environ['INPUT_PIPELINE_FUNCTION_NAME']
+    pipeline_function = load_function(pipeline_function_name=pipeline_function_name,
                                       full_path_to_pipeline=os.environ['INPUT_PIPELINE_CODE_PATH'])
 
-    logging.info("The value of the VERSION_GITHUB_SHA is: {}".format(os.environ["INPUT_VERSION_GITHUB_SHA"]))
-
+    github_sha = os.getenv["GITHUB_SHA"]
     if os.environ["INPUT_VERSION_GITHUB_SHA"] == "true":
-        logging.info("Versioned pipeline components")
-        pipeline_function = pipeline_function(github_sha=os.environ["GITHUB_SHA"])
+        logging.info(f"Versioned pipeline components with : {github_sha}")
+        pipeline_function = pipeline_function(github_sha=github_sha)
 
     pipeline_name_zip = pipeline_compile(pipeline_function=pipeline_function)
-    pipeline_name = os.environ['INPUT_PIPELINE_FUNCTION_NAME'] + "_" + os.environ["GITHUB_SHA"]
-
+    pipeline_name = f"{pipeline_function_name}_{github_sha}"
     client = upload_pipeline(pipeline_name_zip=pipeline_name_zip,
                              pipeline_name=pipeline_name,
                              kubeflow_url=os.environ['INPUT_KUBEFLOW_URL'])
@@ -224,14 +232,13 @@ def main():
 
         pipeline_id = find_pipeline_id(pipeline_name=pipeline_name,
                                        client=client)
-
         run_pipeline_func(pipeline_name=pipeline_name,
-                     pipeline_id=pipeline_id,
-                     client=client,
-                     pipeline_paramters_path=os.environ["INPUT_PIPELINE_PARAMETERS_PATH"],
-                     recurring_flag = os.environ['INPUT_RUN_RECURRING_PIPELINE'],
-                     cron_exp = os.environ['INPUT_CRON_EXPRESSION'])
-        
-    
+                          pipeline_id=pipeline_id,
+                          client=client,
+                          pipeline_paramters_path=os.environ["INPUT_PIPELINE_PARAMETERS_PATH"],
+                          recurring_flag=os.environ['INPUT_RUN_RECURRING_PIPELINE'],
+                          cron_exp=os.environ['INPUT_CRON_EXPRESSION'])
+
+
 if __name__ == "__main__":
     main()

--- a/main.py
+++ b/main.py
@@ -178,21 +178,22 @@ def run_pipeline_func(client: kfp.Client,
     pipeline_params = pipeline_params if pipeline_params is not None else {}
 
     experiment_id = None
+    experiment_name = "{}-{}".format(pipeline_name,
+                                     os.environ["INPUT_EXPERIMENT_NAME"])
     try:
         experiment_id = client.get_experiment(
-            experiment_name=os.environ["INPUT_EXPERIMENT_NAME"]
+            experiment_name=experiment_name
         ).to_dict()["id"]
     except ValueError:
-        client.create_experiment(os.environ["INPUT_EXPERIMENT_NAME"])
-        experiment_id = client.get_experiment(
-            experiment_name=os.environ["INPUT_EXPERIMENT_NAME"]
+        experiment_id = client.create_experiment(
+            experiment_name=experiment_name
         ).to_dict()["id"]
 
     namespace = os.getenv("INPUT_PIPELINE_NAMESPACE") if not str.isspace(
         os.getenv("INPUT_PIPELINE_NAMESPACE")) else None
 
     job_name = 'Run {} on {}'.format(pipeline_name,
-                                     datetime.now().strftime("%Y_%m_%d_%H_%M_%S"))
+                                     datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
 
     logging.info(f"experiment_id: {experiment_id}, \
                  job_name: {job_name}, \


### PR DESCRIPTION
# Overview
I made some updates below:-

 - Code refactoring
 - Fix typo
 - Making finding `pipeline_id` and `experiment_id` from kubeflow easier and more simple (according to official implementation)
 - Applying `experiment_name` to pipeline from environment variables
 - Update the procedure of assigning pipeline and experiment name


# Test procedure
Run the github action after changing a base branch `master` to `fix_set_experiment-name` in mail_retention_pipeline: https://github.com/st-tech/zozo-mail-retention-pipeline/runs/1197627251

Please check!